### PR TITLE
Update hexo_resize_image.js

### DIFF
--- a/hexo_resize_image.js
+++ b/hexo_resize_image.js
@@ -50,4 +50,4 @@ function hexo_resize_image()
         }
     }
 }
-window.onload = hexo_resize_image;
+document.addEventListener("DOMContentLoaded", hexo_resize_image);


### PR DESCRIPTION
在DOMContentLoaded 事件发生时执行 hexo_resize_image 函数，而不是在窗口完全加载之后再执行，这样可以防止图片加载时仍然显示原始大小。